### PR TITLE
PR: Tracking a team's total number of right answers

### DIFF
--- a/scoring/src/components/teams/Team.js
+++ b/scoring/src/components/teams/Team.js
@@ -1,10 +1,11 @@
 import './Team.css';
 
-const Team = ({ team: { name, points, winStreak, connected } }) => {
+const Team = ({ team: { name, points, totalWins, winStreak, connected } }) => {
   return (
     <div className={`team ${connected ? 'connected' : 'disconnected'}`}>
       <h2>{name}</h2>
       <div>Score : {points}</div>
+      <div>Wins : {totalWins}</div>
       <div>Streak : {winStreak}</div>
       <div className={`connection ${connected ? 'connected' : 'disconnected'}`}>
         {connected ? 'Connected' : 'Disconnected'}

--- a/scoring/src/components/teams/Team.js
+++ b/scoring/src/components/teams/Team.js
@@ -3,7 +3,7 @@ import './Team.css';
 const Team = ({ team: { name, points, totalWins, winStreak, connected } }) => {
   return (
     <div className={`team ${connected ? 'connected' : 'disconnected'}`}>
-      <h2>{name}</h2>
+      <h2>{points !== 0 ? `${rank}. ` : null}{name}</h2>
       <div>Score : {points}</div>
       <div>Wins : {totalWins}</div>
       <div>Streak : {winStreak}</div>

--- a/scoring/src/components/teams/Teams.js
+++ b/scoring/src/components/teams/Teams.js
@@ -4,8 +4,8 @@ import "./Teams.css";
 const Teams = ({ teams = [] }) => {
   return (
     <div className="teams">
-      {teams.map((team) => (
-        <Team key={team.name} team={team} />
+      {teams.map((team, index) => (
+        <Team key={team.name} rank={index + 1} team={team} />
       ))}
     </div>
   );

--- a/server/src/team/team.test.ts
+++ b/server/src/team/team.test.ts
@@ -7,19 +7,21 @@ const expectedInvoice: Invoice = '42.00 €';
 const expectedPrice = 42;
 
 describe('Team class', () => {
-  it('should add points and increase win streak on valid invoice', () => {
+  it('should add points and increase win total and winstreak on valid invoice', () => {
     const team = new Team('My awesome team');
 
     expect(team.points).toBe(0);
+    expect(team.totalWins).toBe(0);
     expect(team.winStreak).toBe(0);
 
     team.validateInvoice(expectedInvoice, expectedInvoice, expectedPrice);
 
     expect(team.points).toBe(expectedPrice);
+    expect(team.totalWins).toBe(1);
     expect(team.winStreak).toBe(1);
   });
 
-  it('should remove points with "wrongAnswerFactor" and reset win streak on wrong invoice', () => {
+  it('should remove points with "wrongAnswerFactor" and reset winstreak on wrong invoice', () => {
     const team = new Team('My awesome team');
     team.points = 100;
     team.winStreak = 5;
@@ -42,15 +44,17 @@ describe('Team class', () => {
     expect(team.hasAnswerLast).toBe(false);
   });
 
-  it('should not remove points nor reset winstreak on new cart if team has answered previous invoice with valid answer', () => {
+  it('should not remove points nor reset win total or winstreak on new cart if team has answered previous invoice with valid answer', () => {
     const team = new Team('My awesome team');
 
     team.validateInvoice(expectedInvoice, expectedInvoice, expectedPrice);
     expect(team.points).toBe(expectedPrice);
+    expect(team.totalWins).toBe(1);
     expect(team.winStreak).toBe(1);
 
     gameEvents.emit('newCart', {}, expectedPrice, expectedInvoice);
     expect(team.points).toBe(expectedPrice);
+    expect(team.totalWins).toBe(1);
     expect(team.winStreak).toBe(1);
   });
 
@@ -64,23 +68,27 @@ describe('Team class', () => {
     expect(team.points).toBe(-expectedPrice * wrongAnswerFactor);
   });
 
-  it('should remove points with "noAnswerFactor" and reset winstreak on new cart if team has not answered previous invoice at all', () => {
+  it('should remove points with "noAnswerFactor" and reset winstreak on new cart without resetting win total if team has not answered previous invoice at all', () => {
     const team = new Team('My awesome team');
     team.points = 100;
+    team.totalWins = 5;
     team.winStreak = 5;
 
     gameEvents.emit('newCart', {}, expectedPrice, expectedInvoice);
     expect(team.points).toBe(100 - expectedPrice * noAnswerFactor);
+    expect(team.totalWins).toBe(5);
     expect(team.winStreak).toBe(0);
   });
 
-  it('should reset winstreak without changing points on difficulty increase', () => {
+  it('should reset winstreak without changing points or win total on difficulty increase', () => {
     const team = new Team('My awesome team');
     team.points = 100;
+    team.totalWins = 5;
     team.winStreak = 5;
 
     gameEvents.emit('difficultyUpgrade');
     expect(team.points).toBe(100);
+    expect(team.totalWins).toBe(5);
     expect(team.winStreak).toBe(0);
   });
 });

--- a/server/src/team/team.ts
+++ b/server/src/team/team.ts
@@ -9,6 +9,7 @@ export class Team {
   hasAnswerLast = true;
   points = 0;
   name: string;
+  totalWins = 0;
   winStreak = 0;
   connected = false;
 
@@ -25,6 +26,11 @@ export class Team {
 
     gameEvents.on('difficultyUpgrade', () => this.resetWinStreak());
   }
+
+  increaseTotalNbrOfWins = (): void => {
+    this.totalWins += 1;
+    this.increaseWinStreak();
+  };
 
   resetWinStreak = (): void => {
     this.winStreak = 0;
@@ -52,7 +58,7 @@ export class Team {
 
     if (isInvoiceValid(invoice, expectedInvoice)) {
       this.points += Math.round(expectedPrice);
-      this.increaseWinStreak();
+      this.increaseTotalNbrOfWins();
       return `OK | your points: ${this.points}`;
     } else {
       this.points -= Math.round(expectedPrice * wrongAnswerFactor);


### PR DESCRIPTION
A very small PR to enhance the mood during challenge sessions.

Additions:
- Added tracking of a team's total number of right answers, as opposed to only the current winstreak and points,
- Added displaying of a team's total number of right answers in said team's scoreboard entry.

Enhancements:
- Added the team's current rank index in the team scoreboard entry.